### PR TITLE
[arbitrager] Upgrade dependencies

### DIFF
--- a/arbitrager/package.json
+++ b/arbitrager/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@openzeppelin/contracts": "^3.4.0",
     "@types/chai": "^4.2.21",
-    "@types/mocha": "^5.2.7",
+    "@types/mocha": "^9.0.0",
     "chai": "^4.3.4",
     "ethereum-waffle": "3.4.0",
     "ethers": "^5.4.5",

--- a/arbitrager/yarn.lock
+++ b/arbitrager/yarn.lock
@@ -1513,10 +1513,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/mocha@^5.2.7":
-  version "5.2.7"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
-  integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
+"@types/mocha@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.0.0.tgz#3205bcd15ada9bc681ac20bef64e9e6df88fd297"
+  integrity sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==
 
 "@types/node-fetch@^2.5.12":
   version "2.5.12"


### PR DESCRIPTION
This PR includes bumps to all of the dependencies in the `arbitrager` example. Each is separated in its own commit and most don't include any breaking changes.

The upgraded dependencies are:
- [x] `@acala-network/api 2.0.2-2 -> 2.2.1` (this one is crucial for being able to deploy the example)
- [x] `@acala-network/contracts 1.0.22 -> 1.0.23`
- [x] `@types/chai 4.2.3 -> 4.2.21`
- [x] `chai 4.2.0 -> 4.3.4`
- [x] `ethereum-waffle 3.0.0 -> 3.4.0`
- [x] `ethers 5.0.21 -> 5.4.5`
- [x] `typescript 4.2.4 -> 4.3.5`
- [x] `@polkadot/api 5.2.1 -> 5.6.1`
- [x] `@polkadot/types 5.2.1 -> 5.6.1`
- [x] `@openzeppelin/contracts 3.0.0 -> 3.4.0`
- [x] `mocha 7.1.2 -> 9.1.0`
- [x] `ts-node 8.9.1 -> 10.2.1`
- [x] `@types/mocha 5.2.7 -> 9.0.0`

The ones that do have breaking changes that don't impact the example:

- `@openzeppelin/contracts`
  - `ERC20Snapshot`: switched to using `_beforeTokenTransfer` hook instead of overriding ERC20 operations.
- `mocha`:
  - Drop Node.js v10.x support.
- `ts-node`:
  - Remove support for node 10. Minimum supported version is node 12.
- `@types/mocha`:
  - Unable to locate changelog, but since arbitrager example has no tests at the moment, it's safe to include this upgrade

_NOTE: When `Solidity` and `solc` versions are bumped to `0.8.x`, `@openzeppelin/contracts` should be upgraded to the latest stable version. It is now at the last version that supports `Solidity` and `solc` `0.6.x`._