### PR TITLE
[Arbitrager] Refinement and add unit tests

### DIFF
--- a/arbitrager/README.md
+++ b/arbitrager/README.md
@@ -116,7 +116,19 @@ the **Arbitrager** smart contract receives the following parameters:
 - Address of the Uniswap router
 - Address of the AUSD smart contract
 - Address of the DOT smart contract
-- Period to be passed to the **Scheduler**
+
+Address of the **Arbitrager** instance is displayed:
+
+```
+Arbitrager is deployed at: 0x2C35427755efCF0272617A300D361C3bd3AE40A8
+```
+
+The **Scheduler** is then called and the call to `trigger()` function is scheduled and the `task_id`
+of the call is saved and displayed:
+
+```
+task_id for managing Scheduler subscription is: 0x305363686564756c6543616c6c5c010000efc11ca128ad06d2df4089df8e168c7e7dc81e9800
+```
 
 The `period` parameter is used to set the minimum number of blocks the **Scheduler** has to wait
 before calling the `trigger()` function.
@@ -126,17 +138,23 @@ When the **Arbitrager** smart contract is deployed the following steps occur:
 1. It assigns the addresses passed to the constructor to the global variables
 2. It approves the Uniswap router to handle the tokens owned by the address that deployed the
 contract (in our case, that would be the *deployer*)
-3. It schedules the call of the `trigger()` function with the native **Scheduler** smart contract
 
-    - The period passed to the constructor is used to tell the **Scheduler** how many blocks should
-    pass from the call being scheduled to its execution
+Deploy script then schedules the call of the `trigger()` function with the native **Scheduler**
+smart contract
+
+    - The period passed to the scheduleTriggerCall is used to tell the **Scheduler** how many blocks
+    should pass from the call being scheduled to its execution
     - All other inputs are hadcoded in this example
     - To read more about how **Scheduler** works, please consult the [wiki](https://wiki.acala.network/build/development-guide/smart-contracts/advanced/use-on-chain-scheduler)
 
-After the **Arbitrager** is successfully deployed, the script transfers the tokens to its address.
-The deploy script then sets the prices of the tokens in order for the **Arbitrager** to be able to
-determine which token is should swap for which. The price of *AUSD* is set to *1000* and the price
-of *DOT* is set to *2000*.
+When the **Scheduler** call is configured, the deployer retrieves the *task_id* from the event
+emmited by **Scheduler** and saves it to a global variable within **Arbitrager** using `setTaskId()`
+function.
+
+After the **Arbitrager** is successfully deployed and configured, the script transfers the tokens to
+its address. The deploy script then sets the prices of the tokens in order for the **Arbitrager** to
+be able to determine which token is should swap for which. The price of *AUSD* is set to *1000* and
+the price of *DOT* is set to *2000*.
 
 The balances of AUSD and DOT tokens for the **Arbitrager** smart contract and for the liquidity pool
 are printed out:
@@ -192,3 +210,6 @@ can see that the `trigger()` has been called again:
   lpAmountDOT: '1002710000000000'
 }
 ```
+
+The end of the deployer script contains the examples how the `rescheduleCall()` and `cancelCall()`
+of the **Scheduler** are used, but they require further refinement at this point.

--- a/arbitrager/contracts/Arbitrager.sol
+++ b/arbitrager/contracts/Arbitrager.sol
@@ -17,24 +17,22 @@ contract Arbitrager is ADDRESS {
     IUniswapV2Router01 public immutable router;
     IERC20 public immutable tokenA;
     IERC20 public immutable tokenB;
-    uint256 public immutable period;
+    uint256 public period;
+    bytes public schedulerTaskId;
 
     uint256 constant MAX_INT = uint256(-1);
 
-    /// @notice Constructor sets the global variables and schedules execution of trigger with Scheduler
+    /// @notice Constructor sets the global variables
     /// @param factory_ address Address of the Uniswap Factory
     /// @param router_ address Address of the Uniswap V2 Router 01 smart contract
     /// @param tokenA_ address Address of the first token's smart contract 
     /// @param tokenB_ address Address of the second token's smart contract 
-    /// @param period_ uint The amount of time to elapse from deploying this contract to having Scheduler trigger the trigger() function
     /// @dev The constructor sets the approval of both tokens to maximum available value (2^256 - 1)
-    /// @dev Scheduler is called with hardcoded values for now, with only period_ being dynamic
     constructor(
         address factory_,
         IUniswapV2Router01 router_,
         IERC20 tokenA_,
-        IERC20 tokenB_,
-        uint period_
+        IERC20 tokenB_
     )
         public
     {
@@ -43,21 +41,61 @@ contract Arbitrager is ADDRESS {
         router = router_;
         tokenA = tokenA_;
         tokenB = tokenB_;
-        period = period_;
 
         // Set approval amount for tokens at maximum possible value
         tokenA_.approve(address(router_), MAX_INT);
         tokenB_.approve(address(router_), MAX_INT);
+    }
 
-        // Call Scheduler smart contract and schedule a call of trigger() function
-        ISchedule(ADDRESS.Schedule).scheduleCall(
-                                        address(this),
-                                        0,
-                                        1000000,
-                                        5000,
-                                        period_,
-                                        abi.encodeWithSignature("trigger()")
-                                    );
+    /// @notice Call Scheduler smart contract and schedule a call of trigger() function
+    /// @param period_ uint The amount of time to elapse from deploying this contract to having Scheduler trigger the trigger() function
+    /// @return bool Signals successful execution of the function
+    /// @dev Scheduler is called with hardcoded values for now, with only period_ being dynamic
+    /// @dev This function should be protected by access control if used for purposes other than demo
+    function scheduleTriggerCall(uint period_) public returns(bool){
+        require(keccak256(schedulerTaskId) == keccak256(bytes("")), "The call is already schdeuled!");
+
+        period = period_;
+
+        require(ISchedule(ADDRESS.Schedule).scheduleCall(
+                                                address(this),
+                                                0,
+                                                1000000,
+                                                5000,
+                                                period_,
+                                                abi.encodeWithSignature("trigger()")
+                                            ));
+        return true;
+    }
+
+    /// @notice Sets the task_id that was assigned to the call to trigger with on-chain Scheduler
+    /// @param task_id_ bytes task_id assigned to the call to trigger() by the on-chain Scheduler
+    /// @return bool Signals successful execution of the function
+    /// @dev This function should be protected by access control if used for purposes other than demo
+    function setTaskId(bytes memory task_id_) public returns(bool) {
+        require(keccak256(schedulerTaskId) == keccak256(bytes("")), "task_id is already set!");
+
+        schedulerTaskId = task_id_;
+        return true;
+    }
+
+    /// @notice Sets a new min_delay for the call of trigger() function with the on-chain Scheduler
+    /// @param newPeriod uint New minimum amout of blocks before the Scheduler calls the trigger() function
+    /// @return bool Signals successful execution of the function
+    /// @dev This function should be protected by access control if used for purposes other than demo
+    function rescheduleTriggerCall(uint newPeriod) public returns(bool){
+        period = newPeriod;
+        require(ISchedule(ADDRESS.Schedule).rescheduleCall(newPeriod, schedulerTaskId));
+        return true;
+    }
+
+    /// @notice Cancels the call of trigger() function with the on-chain Scheduler
+    /// @return bool Signals successful execution of the function
+    /// @dev This function should be protected by access control if used for purposes other than demo
+    function cancelTriggerCall() public returns(bool){
+        require(ISchedule(ADDRESS.Schedule).cancelCall(schedulerTaskId));
+        delete schedulerTaskId;
+        return true;
     }
 
     /// @notice Calculates how many of which token to swap with the other token

--- a/arbitrager/package.json
+++ b/arbitrager/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "deploy": "node -r ts-node/register/transpile-only src/deploy.ts",
-    "build": "waffle waffle.json"
+    "build": "waffle waffle.json",
+    "test": "export NODE_ENV=test && mocha -r ts-node/register/transpile-only --timeout 50000 --no-warnings test/**/*.test.{js,ts}"
   },
   "resolutions": {
     "@polkadot/api": "^5.6.1",

--- a/arbitrager/src/deploy.ts
+++ b/arbitrager/src/deploy.ts
@@ -1,17 +1,48 @@
-import { Contract, ContractFactory, BigNumber } from "ethers";
+import { Contract, ContractFactory, BigNumber, ethers } from "ethers";
 import ADDRESS from "@acala-network/contracts/utils/Address";
 
 import UniswapFactory from "../artifacts/UniswapV2Factory.json";
 import UniswapRouter from "../artifacts/UniswapV2Router02.json";
 import Arbitrager from "../build/Arbitrager.json";
+import ISchedule from "../build/ISchedule.json";
 import IERC20 from "../artifacts/IERC20.json";
 import setup from "./setup";
+
+import { hexlify } from "ethers/lib/utils";
 
 const main = async () => {
     const { wallet, provider, pair } = await setup();
     const deployerAddress = await wallet.getAddress();
     const tokenAUSD = new Contract(ADDRESS.AUSD, IERC20.abi, wallet);
     const tokenDOT = new Contract(ADDRESS.DOT, IERC20.abi, wallet);
+    const schedulerAbi = require("@acala-network/contracts/build/contracts/Schedule.json").abi
+    const scheduler = new Contract(ADDRESS.Schedule, schedulerAbi, wallet as any);
+    // const scheduler = new Contract(ADDRESS.Schedule, ISchedule.abi, wallet);
+
+    const nextBlock = async () => {
+      return new Promise((resolve) => {
+        provider.api.tx.system.remark('').signAndSend(pair, (result) => {
+          if (result.status.isInBlock) {
+            resolve(undefined);
+          }
+        });
+      });
+    };
+
+    const printBalance = async () => {
+      const amountAUSD = await tokenAUSD.balanceOf(arbitrager.address);
+      const amountDOT = await tokenDOT.balanceOf(arbitrager.address);
+      const lpAmountAUSD = await tokenAUSD.balanceOf(tradingPairAddress);
+      const lpAmountDOT = await tokenDOT.balanceOf(tradingPairAddress);
+
+      console.log({
+        arbitrager: arbitrager.address,
+        amountAUSD: amountAUSD.toString(),
+        amountDOT: amountDOT.toString(),
+        lpAmountAUSD: lpAmountAUSD.toString(),
+        lpAmountDOT: lpAmountDOT.toString(),
+      })
+    };
 
     console.log('Deploy Uniswap');
 
@@ -24,7 +55,7 @@ const main = async () => {
     console.log({
         factory: factory.address,
         router: router.address,
-    })
+    });
 
     await tokenAUSD.approve(router.address, BigNumber.from(10).pow(18));
     await tokenDOT.approve(router.address, BigNumber.from(10).pow(18));
@@ -43,47 +74,46 @@ const main = async () => {
         lpTokenAmount: lpTokenAmount.toString(),
         liquidityPoolAmountAUSD: amountAUSD.toString(),
         liquidityPoolAmountDOT: amountDOT.toString(),
-    })
+    });
 
     console.log('Deploy Arbitrager');
 
-    // deploy arbitrager, scheduled every 3 blocks
-    
+    // deploy arbitrager
     const arbitrager = await ContractFactory.fromSolidity(Arbitrager).connect(wallet)
-        .deploy(factory.address, router.address, ADDRESS.AUSD, ADDRESS.DOT, 1);
+        .deploy(factory.address, router.address, ADDRESS.AUSD, ADDRESS.DOT);
+
+    console.log("Arbitrager is deployed at: " + arbitrager.address);
+
+    let iface = new ethers.utils.Interface(schedulerAbi);
+
+    let current_block_number = Number(await provider.api.query.system.number());
+
+    // schedule trigger() call every 3 blocks
+    await arbitrager.scheduleTriggerCall(1);
+
+    // get task_id form Event emitted by Scheduler
+    let block_hash = await provider.api.query.system.blockHash(current_block_number);
+    const data = await provider.api.derive.tx.events(block_hash);
+    let event = data.events.filter(item => item.event.data.some(data => data.address == ADDRESS.Schedule && data.topics[0] == iface.getEventTopic(iface.getEvent("ScheduledCall"))));
+
+    let log = {
+      topics: [event[0].event.data[0].topics[0].toString(), event[0].event.data[0].topics[1].toString(), event[0].event.data[0].topics[2].toString()], data: event[0].event.data[0].data.toString()
+    };
+    let decode_log = await iface.parseLog(log);
+
+    const task_id = decode_log.args.task_id;
+
+    console.log("task_id for managing Scheduler subscription is: " + task_id);
+
+    // save task_id to Arbitrager
+    await arbitrager.setTaskId(ethers.utils.hexlify(task_id));
 
     await tokenAUSD.transfer(arbitrager.address, BigNumber.from(10).pow(13));
     await tokenDOT.transfer(arbitrager.address, BigNumber.from(10).pow(13));
 
-    const printBalance = async () => {
-        const amountAUSD = await tokenAUSD.balanceOf(arbitrager.address);
-        const amountDOT = await tokenDOT.balanceOf(arbitrager.address);
-        const lpAmountAUSD = await tokenAUSD.balanceOf(tradingPairAddress);
-        const lpAmountDOT = await tokenDOT.balanceOf(tradingPairAddress);
-
-        console.log({
-            arbitrager: arbitrager.address,
-            amountAUSD: amountAUSD.toString(),
-            amountDOT: amountDOT.toString(),
-            lpAmountAUSD: lpAmountAUSD.toString(),
-            lpAmountDOT: lpAmountDOT.toString(),
-        })
-    }
-
     await provider.api.tx.acalaOracle.feedValues([[{ Token: 'AUSD'}, 1000], [{ Token: 'DOT'}, 2000]]).signAndSend(pair);
 
     await printBalance();
-
-    const nextBlock = async () => {
-        return new Promise((resolve) => {
-          provider.api.tx.system.remark('').signAndSend(pair, (result) => {
-            if (result.status.isInBlock) {
-              resolve(undefined);
-            }
-          });
-        });
-      }
-
     
     await nextBlock();
     await nextBlock();
@@ -99,6 +129,30 @@ const main = async () => {
     await nextBlock();
 
     await printBalance();
+
+    // change the Scheduler subscription to call trigger() every 5th block
+    // console.log("Update Scheduler subscription");
+    // await scheduler.rescheduleCall(5, ethers.utils.formatBytes32String(task_id));
+    // console.log("foo");
+    // await arbitrager.rescheduleTriggerCall(4);
+
+    // await nextBlock();
+    // await nextBlock();
+
+    // // balances don't change, since the Scheduler subscription has been modified
+    // console.log("Since not enough time has elapsed, balance has not changed:");
+    // await printBalance();
+
+    // await nextBlock();
+    // await nextBlock();
+
+    // // the trigger() was called
+    // console.log("Now the updated trigger() call comes into effect:");
+    // await printBalance();
+
+    // cancel the trigger() call subscription with Scheduler
+    // console.log("Cancel the trigger() call subscription with Scheduler");
+    // await arbitrager.cancelTriggerCall();
 
     provider.api.disconnect();
 }

--- a/arbitrager/test/Arbitrager.test.ts
+++ b/arbitrager/test/Arbitrager.test.ts
@@ -1,0 +1,195 @@
+import { TestProvider, Signer, TestAccountSigningKey } from "@acala-network/bodhi";
+import { evmChai } from "@acala-network/bodhi/evmChai";
+import { WsProvider } from "@polkadot/api";
+import { createTestPairs } from "@polkadot/keyring/testingPairs";
+import { expect, use } from "chai";
+import { deployContract, solidity } from "ethereum-waffle";
+import { Contract, ContractFactory, BigNumber, ethers } from "ethers";
+import ADDRESS from "@acala-network/contracts/utils/Address";
+
+import UniswapFactory from "../artifacts/UniswapV2Factory.json";
+import UniswapRouter from "../artifacts/UniswapV2Router02.json";
+import Arbitrager from "../build/Arbitrager.json";
+import IERC20 from "../artifacts/IERC20.json";
+import { Bytes, SigningKey } from "ethers/lib/utils";
+import { it } from "mocha";
+
+use(solidity);
+use(evmChai);
+
+const provider = new TestProvider({
+    provider: new WsProvider("ws://127.0.0.1:9944"),
+});
+
+const SCHEDULE_CALL_ABI = require("@acala-network/contracts/build/contracts/Schedule.json").abi;
+
+describe("Arbitrager", () => {
+
+    const pair = createTestPairs().alice;
+    const signingKey = new TestAccountSigningKey(provider.api.registry);
+    signingKey.addKeyringPair(pair);
+
+    let factory: Contract;
+    let router: Contract;
+    let arbitrager: Contract;
+    let tokenAUSD: Contract;
+    let tokenDOT: Contract;
+    let wallet: Signer;
+    let schedulerTaskId: Bytes;
+    
+    before(async () => {
+        await provider.api.isReady;
+
+        wallet = new Signer(provider, pair.address, signingKey);
+        const deployer = await wallet.getAddress();
+
+        tokenAUSD = new Contract(ADDRESS.AUSD, IERC20.abi, wallet);
+        tokenDOT = new Contract(ADDRESS.DOT, IERC20.abi, wallet);
+
+        factory = await ContractFactory.fromSolidity(UniswapFactory).connect(wallet).deploy(deployer);
+        router = await ContractFactory.fromSolidity(UniswapRouter).connect(wallet).deploy(factory.address, ADDRESS.ACA);
+
+        await tokenAUSD.approve(router.address, BigNumber.from(10).pow(18));
+        await tokenDOT.approve(router.address, BigNumber.from(10).pow(18));
+
+        await router.addLiquidity(ADDRESS.AUSD, ADDRESS.DOT, BigNumber.from(10).pow(15), BigNumber.from(10).pow(15), 0, 0, deployer, 10000000000);
+
+        arbitrager = await ContractFactory.fromSolidity(Arbitrager).connect(wallet).deploy(factory.address, router.address, ADDRESS.AUSD, ADDRESS.DOT);
+
+        expect(arbitrager.address).to.be.properAddress;
+
+        let iface = new ethers.utils.Interface(SCHEDULE_CALL_ABI);
+
+        let current_block_number = Number(await provider.api.query.system.number());
+
+        await arbitrager.scheduleTriggerCall(1);
+
+        let block_hash = await provider.api.query.system.blockHash(current_block_number);
+        const data = await provider.api.derive.tx.events(block_hash);
+        let event = data.events.filter(item => item.event.data.some(data => data.address == ADDRESS.Schedule && data.topics[0] == iface.getEventTopic(iface.getEvent("ScheduledCall"))));
+        
+        if (event.length > 0) {
+            let log = {
+                topics: [event[0].event.data[0].topics[0].toString(), event[0].event.data[0].topics[1].toString(), event[0].event.data[0].topics[2].toString()], data: event[0].event.data[0].data.toString()
+            };
+            let decode_log = await iface.parseLog(log);
+
+            schedulerTaskId = decode_log.args.task_id;
+
+            await arbitrager.setTaskId(ethers.utils.hexlify(schedulerTaskId));
+        } else {
+            expect(false).to.not.be.ok;
+        }
+
+        await tokenAUSD.transfer(arbitrager.address, BigNumber.from(10).pow(13));
+        await tokenDOT.transfer(arbitrager.address, BigNumber.from(10).pow(13));
+        
+        
+        expect(await tokenAUSD.balanceOf(arbitrager.address)).to.equal(BigNumber.from(10).pow(13));
+        expect(await tokenDOT.balanceOf(arbitrager.address)).to.equal(BigNumber.from(10).pow(13));
+    });
+
+    after(async () => {
+        provider.api.disconnect();
+    });
+
+    const nextBlock = async () => {
+        return new Promise((resolve) => {
+            provider.api.tx.system.remark('').signAndSend(pair, (result) => {
+                if (result.status.isInBlock) {
+                    resolve(undefined);
+                }
+            });
+        });
+    }
+
+    it("successfuly deploys the contract", () => {
+        expect(arbitrager.address).to.be.properAddress;
+    });
+
+    it("correctly sets the global variables upon being deployed", async () => {
+        const factoryAddress = await arbitrager.factory();
+        const routerAddress = await arbitrager.router();
+        const tokenAAddress = await arbitrager.tokenA();
+        const tokenBAddress = await arbitrager.tokenB();
+        const assignedPeriod = await arbitrager.period();
+
+        expect(factoryAddress).to.equal(factory.address);
+        expect(routerAddress).to.equal(router.address);
+        expect(tokenAAddress).to.equal(tokenAUSD.address);
+        expect(tokenBAddress).to.equal(tokenDOT.address);
+        expect(assignedPeriod).to.equal(1);
+    });
+
+    it("sets the schedulerTaskId variable", async () => {
+        expect(await arbitrager.schedulerTaskId()).to.equal(schedulerTaskId);
+    });
+
+    it("sets the initial period variable", async () => {
+        expect(await arbitrager.period()).to.equal(1);
+    });
+
+    it("prohibits calling trigger() by anyone other than self", async () => {
+        await expect(arbitrager.trigger({ from: wallet })).to.be.reverted;
+    });
+
+    it("buys AUSD if it is cheaper than DOT", async () => {
+        await provider.api.tx.acalaOracle.feedValues([[{ Token: 'AUSD' }, 1000], [{ Token: 'DOT' }, 2000]]).signAndSend(pair);
+
+        const initialBalanceAUSD = await await tokenAUSD.balanceOf(arbitrager.address);
+        const initialBalanceDOT = await await tokenDOT.balanceOf(arbitrager.address);
+
+        await nextBlock();
+        await nextBlock();
+
+        const balanceAUSD = await await tokenAUSD.balanceOf(arbitrager.address);
+        const balanceDOT = await await tokenDOT.balanceOf(arbitrager.address);
+
+        expect(balanceDOT).to.be.below(initialBalanceDOT);
+        expect(balanceAUSD).to.be.above(initialBalanceAUSD);
+    });
+
+    it("buys DOT if it is cheaper than AUSD", async () => {
+        await provider.api.tx.acalaOracle.feedValues([[{ Token: 'AUSD' }, 2000], [{ Token: 'DOT' }, 1000]]).signAndSend(pair);
+
+        const initialBalanceAUSD = await await tokenAUSD.balanceOf(arbitrager.address);
+        const initialBalanceDOT = await await tokenDOT.balanceOf(arbitrager.address);
+
+        await nextBlock();
+        await nextBlock();
+
+        const balanceAUSD = await await tokenAUSD.balanceOf(arbitrager.address);
+        const balanceDOT = await await tokenDOT.balanceOf(arbitrager.address);
+
+        expect(balanceDOT).to.be.above(initialBalanceDOT);
+        expect(balanceAUSD).to.be.below(initialBalanceAUSD);
+    });
+
+    it("schedules another trigger() call after trigger() is called", async () => {
+        await provider.api.tx.acalaOracle.feedValues([[{ Token: 'AUSD' }, 1000], [{ Token: 'DOT' }, 2000]]).signAndSend(pair);
+
+        await nextBlock();
+        await nextBlock();
+
+        const firstBalanceAUSD = await await tokenAUSD.balanceOf(arbitrager.address);
+
+        await nextBlock();
+        await nextBlock();
+
+        const secondBalanceAUSD = await await tokenAUSD.balanceOf(arbitrager.address);
+
+        expect(firstBalanceAUSD).not.to.be.equal(secondBalanceAUSD);
+    });
+
+    // it("reschedules trigger() call with Scheduler", async () => {
+    //     expect(await arbitrager.rescheduleTriggerCall(2)).to.equal(true);
+
+    //     expect(await arbitrager.period()).to.equal(2);
+    // });
+
+    // it("cancels trigger() call with Scheduler", async () => {
+    //     expect(await arbitrager.cancelTriggerCall()).to.equal(true);
+
+    //     expect(await arbitrager.schedulerTaskId()).to.be.empty;
+    // });
+});


### PR DESCRIPTION
This PR contains four distinct commits:

1.  Add `rescheduleCall` and `cancelCall` to `Arbitrager`
   - Added `rescheduleCall` and `cancelCall` of `Schedule` smart contract to `Arbitrager`.
   - `setTaskId` function was added to assist the user by saving the `task_id` of the Schedule's call in order for easier maintenance.
   - Natspec comments were modified to reflect the changes.
 
2. Modify `Arbitrager` deploy script
  - Arbitraged deploy script was updated to reflect the new functions (`scheduleTriggerCall()`, `setTaskId()`, `rescheduleTriggerCall()` and `cancelTriggerCall()`).
  - The latter two are included in the commented out section at the bottom of the script as they need to be refined further (check the bottom of the PR note for further elaboration).

3. Add Arbitrager unit tests
  - Arbitrager unit tests were added.
  - Alias 'yarn test' was created for easier running of the tests.
  - Test include commented out examples of `rescheduleTriggerCall()` and `cancelTriggerCall()`, since they need to be refined further (again, please check the bottom of the PR for further elaboration).
  - The example checking if DOT is being bought is failing and I think that it should be kept and the issue to be corrected in the near future.

4. Update Arbitrager README
  - Arbitrager README was updated to reflect the changes included in this PR.

Reason for `rescheduleTriggerCall()` and `cancelTriggerCall()` needing further requirement:
When running the test as well as deploy script these two calls would error out with the following message:
```
     Error: -32603: execution revert: 0x
      at RpcCoder._checkError (node_modules/@polkadot/rpc-provider/coder/index.cjs:84:13)
      at RpcCoder.decodeResponse (node_modules/@polkadot/rpc-provider/coder/index.cjs:47:10)
      at WsProvider.value (node_modules/@polkadot/rpc-provider/ws/index.cjs:239:90)
      at W3CWebSocket.value [as onmessage] (node_modules/@polkadot/rpc-provider/ws/index.cjs:219:153)
      at W3CWebSocket._dispatchEvent [as dispatchEvent] (node_modules/yaeti/lib/EventTarget.js:107:17)
      at W3CWebSocket.onMessage (node_modules/websocket/lib/W3CWebSocket.js:234:14)
      at WebSocketConnection.<anonymous> (node_modules/websocket/lib/W3CWebSocket.js:205:19)
      at WebSocketConnection.EventEmitter.emit (domain.js:467:12)
      at WebSocketConnection.processFrame (node_modules/websocket/lib/WebSocketConnection.js:554:26)
      at /Users/janturk/Acala/evm-examples/arbitrager/node_modules/websocket/lib/WebSocketConnection.js:323:40
      at processTicksAndRejections (internal/process/task_queues.js:75:11)
```
This error persisted even when `Schedule` was called directly using the `task_id` extracted from the event it emitted when using `scheduleTriggerCall()`. I would love to hear your input on this, if this kind of error was encountered before.