### PR TITLE
Fix Scheduler test examples that always pass

### DIFF
--- a/scheduler/test/Scheduler.test.ts
+++ b/scheduler/test/Scheduler.test.ts
@@ -89,7 +89,7 @@ describe("Schedule", () => {
       console.log("task_id:" + decode_log.args.task_id);
       await schedule.cancelCall(ethers.utils.hexlify(decode_log.args.task_id));
     } else {
-      expect(false).to.not.be.ok;
+      expect(false).to.be.ok;
     }
   });
 
@@ -115,7 +115,7 @@ describe("Schedule", () => {
       console.log("task_id:" + decode_log.args.task_id);
       await schedule.rescheduleCall(5, ethers.utils.hexlify(decode_log.args.task_id));
     } else {
-      expect(false).to.not.be.ok;
+      expect(false).to.be.ok;
     }
   });
 


### PR DESCRIPTION
Two of the `Scheduler` test examples had a clause where even if the event was not detected, the test would pass. This was changed, so that the tests fail in case the event is not emitted.